### PR TITLE
support multiple comma-separated text prompts for grounded sam demo

### DIFF
--- a/grounded_sam_demo.py
+++ b/grounded_sam_demo.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
     image_pil.save(os.path.join(output_dir, "raw_image.jpg"))
 
     # support multiple text prompts
-    text_prompts = text_prompt.split(", ")
+    text_prompts = [prompt.split() for prompt in text_prompt.split(".")]
     # initialize SAM
     predictor = SamPredictor(build_sam(checkpoint=sam_checkpoint))
     image = cv2.imread(image_path)

--- a/grounded_sam_demo.py
+++ b/grounded_sam_demo.py
@@ -99,7 +99,7 @@ def show_box(box, ax, label):
     ax.text(x0, y0, label)
 
 
-def save_mask_data(output_dir, mask_list, box_list, label_list):
+def save_mask_data(output_dir, mask_list, box_list, label_list, text_prompt):
     value = 0  # 0 for background
 
     mask_img = torch.zeros(mask_list.shape[-2:])
@@ -108,7 +108,7 @@ def save_mask_data(output_dir, mask_list, box_list, label_list):
     plt.figure(figsize=(10, 10))
     plt.imshow(mask_img.numpy())
     plt.axis('off')
-    plt.savefig(os.path.join(output_dir, 'mask.jpg'), bbox_inches="tight", dpi=300, pad_inches=0.0)
+    plt.savefig(os.path.join(output_dir, f'mask_{text_prompt}.jpg'), bbox_inches="tight", dpi=300, pad_inches=0.0)
 
     json_data = [{
         'value': value,
@@ -209,11 +209,13 @@ if __name__ == "__main__":
         for box, label in zip(boxes_filt, pred_phrases):
             show_box(box.numpy(), plt.gca(), label)
 
+        save_mask_data(output_dir, masks, boxes_filt, pred_phrases, text_prompt)
+
     plt.axis('off')
     plt.savefig(
         os.path.join(output_dir, "grounded_sam_output.jpg"), 
         bbox_inches="tight", dpi=300, pad_inches=0.0
     )
 
-    save_mask_data(output_dir, masks, boxes_filt, pred_phrases)
+    
 

--- a/grounded_sam_demo.py
+++ b/grounded_sam_demo.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
     image_pil.save(os.path.join(output_dir, "raw_image.jpg"))
 
     # support multiple text prompts
-    text_prompts = [prompt.split() for prompt in text_prompt.split(".")]
+    text_prompts = [prompt.strip() for prompt in text_prompt.split(".")]
     # initialize SAM
     predictor = SamPredictor(build_sam(checkpoint=sam_checkpoint))
     image = cv2.imread(image_path)

--- a/grounded_sam_demo.py
+++ b/grounded_sam_demo.py
@@ -181,6 +181,7 @@ if __name__ == "__main__":
     # initialize image plot
     plt.figure(figsize=(10, 10))
     plt.imshow(image)
+    all_masks = []
     for text_prompt in text_prompts:
         # run grounding dino model
         boxes_filt, pred_phrases = get_grounding_output(
@@ -202,6 +203,7 @@ if __name__ == "__main__":
             boxes = transformed_boxes,
             multimask_output = False,
         )
+        all_masks.append(masks)
 
         # draw output image
         for mask in masks:
@@ -209,7 +211,7 @@ if __name__ == "__main__":
         for box, label in zip(boxes_filt, pred_phrases):
             show_box(box.numpy(), plt.gca(), label)
 
-        save_mask_data(output_dir, masks, boxes_filt, pred_phrases, text_prompt)
+
 
     plt.axis('off')
     plt.savefig(
@@ -217,5 +219,6 @@ if __name__ == "__main__":
         bbox_inches="tight", dpi=300, pad_inches=0.0
     )
 
-    
+    for masks, text_prompt in zip(all_masks, text_prompts):
+        save_mask_data(output_dir, masks, boxes_filt, pred_phrases, text_prompt)
 

--- a/grounded_sam_demo.py
+++ b/grounded_sam_demo.py
@@ -164,48 +164,50 @@ if __name__ == "__main__":
     # make dir
     os.makedirs(output_dir, exist_ok=True)
     # load image
-    image_pil, image = load_image(image_path)
+    image_pil, image_gd = load_image(image_path)
     # load model
     model = load_model(config_file, grounded_checkpoint, device=device)
 
     # visualize raw image
     image_pil.save(os.path.join(output_dir, "raw_image.jpg"))
 
-    # run grounding dino model
-    boxes_filt, pred_phrases = get_grounding_output(
-        model, image, text_prompt, box_threshold, text_threshold, device=device
-    )
-
+    # support multiple text prompts
+    text_prompts = text_prompt.split(", ")
     # initialize SAM
     predictor = SamPredictor(build_sam(checkpoint=sam_checkpoint))
     image = cv2.imread(image_path)
     image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     predictor.set_image(image)
-
-    size = image_pil.size
-    H, W = size[1], size[0]
-    for i in range(boxes_filt.size(0)):
-        boxes_filt[i] = boxes_filt[i] * torch.Tensor([W, H, W, H])
-        boxes_filt[i][:2] -= boxes_filt[i][2:] / 2
-        boxes_filt[i][2:] += boxes_filt[i][:2]
-
-    boxes_filt = boxes_filt.cpu()
-    transformed_boxes = predictor.transform.apply_boxes_torch(boxes_filt, image.shape[:2])
-
-    masks, _, _ = predictor.predict_torch(
-        point_coords = None,
-        point_labels = None,
-        boxes = transformed_boxes,
-        multimask_output = False,
-    )
-    
-    # draw output image
+    # initialize image plot
     plt.figure(figsize=(10, 10))
     plt.imshow(image)
-    for mask in masks:
-        show_mask(mask.cpu().numpy(), plt.gca(), random_color=True)
-    for box, label in zip(boxes_filt, pred_phrases):
-        show_box(box.numpy(), plt.gca(), label)
+    for text_prompt in text_prompts:
+        # run grounding dino model
+        boxes_filt, pred_phrases = get_grounding_output(
+            model, image_gd, text_prompt, box_threshold, text_threshold, device=device
+        )
+        size = image_pil.size
+        H, W = size[1], size[0]
+        for i in range(boxes_filt.size(0)):
+            boxes_filt[i] = boxes_filt[i] * torch.Tensor([W, H, W, H])
+            boxes_filt[i][:2] -= boxes_filt[i][2:] / 2
+            boxes_filt[i][2:] += boxes_filt[i][:2]
+
+        boxes_filt = boxes_filt.cpu()
+        transformed_boxes = predictor.transform.apply_boxes_torch(boxes_filt, image.shape[:2])
+
+        masks, _, _ = predictor.predict_torch(
+            point_coords = None,
+            point_labels = None,
+            boxes = transformed_boxes,
+            multimask_output = False,
+        )
+
+        # draw output image
+        for mask in masks:
+            show_mask(mask.cpu().numpy(), plt.gca(), random_color=True)
+        for box, label in zip(boxes_filt, pred_phrases):
+            show_box(box.numpy(), plt.gca(), label)
 
     plt.axis('off')
     plt.savefig(


### PR DESCRIPTION
Made a small change to support multiple comma-separated text prompts in the grounded sam demo.

Here is an example running the script with `--text-prompt "bear, gravel"`

grounded_sam_output.jpg
![grounded_sam_output](https://user-images.githubusercontent.com/38138126/230797546-f027983a-a0b1-469a-b0d5-99f6c832a97f.jpg)

mask_bear.jpg
![mask_bear](https://user-images.githubusercontent.com/38138126/230797555-fde69117-b747-4cec-90d2-d649d8499852.jpg)

mask_gravel.jpg
![mask_gravel](https://user-images.githubusercontent.com/38138126/230797568-c2fbe0f2-951e-45db-ae12-877c0a3c2676.jpg)


Here is another example running the script with `--text-prompt "rock, boat"`

![grounded_sam_output](https://user-images.githubusercontent.com/38138126/230796658-94e7cd03-9a97-4742-b4f6-c9ee6a3b6f19.jpg)
