### PR TITLE
use "." for better performance

### DIFF
--- a/automatic_label_demo.py
+++ b/automatic_label_demo.py
@@ -56,7 +56,7 @@ def generate_tags(caption, max_tokens=100, model="gpt-3.5-turbo"):
         {
             'role': 'system',
             'content': 'Extrat the unique nouns in the caption. Remove all the adjectives. ' + \
-                       'List the nouns in singular form. Split them by ",". ' + \
+                       'List the nouns in singular form. Split them by ".". ' + \
                        f'Caption: {caption}.'
         }
     ]


### PR DESCRIPTION
Use "." instead of "," for better detection results of GroundingDINO.