### PR TITLE
Add Docker Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 # checkpoint
 *.pth
 outputs/
+
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-devel
 
 COPY . /home/appuser
 WORKDIR /home/appuser
-RUN apt-get update
+RUN apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
+# Below is for https://github.com/IDEA-Research/Grounded-Segment-Anything/issues/53
+ENV CUDA_HOME /usr/local/cuda-11.6/
 RUN python -m pip install -e segment_anything
 RUN python -m pip install -e GroundingDINO
 RUN pip install --upgrade diffusers[torch]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-devel
+
+COPY . /home/appuser
+WORKDIR /home/appuser
+RUN apt-get update
+RUN python -m pip install -e segment_anything
+RUN python -m pip install -e GroundingDINO
+RUN pip install --upgrade diffusers[torch]
+RUN pip install opencv-python pycocotools matplotlib onnxruntime onnx ipykernel

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+build-image:
+	docker build -t=gsa:v0 .
+
+run: build-image
+	nvidia-docker run --gpus all -it --rm --net=host --privileged \
+	-v /tmp/.X11-unix:/tmp/.X11-unix \
+	-e DISPLAY=$DISPLAY \
+	-v ${PWD}:/home/appuser \
+	--name=gsa \
+	--ipc=host -it gsa:v0

--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ See our [notebook file](grounded_sam.ipynb) as an example.
 ## :hammer_and_wrench: Installation
 The code requires `python>=3.8`, as well as `pytorch>=1.7` and `torchvision>=0.8`. Please follow the instructions [here](https://pytorch.org/get-started/locally/) to install both PyTorch and TorchVision dependencies. Installing both PyTorch and TorchVision with CUDA support is strongly recommended.
 
+### Install with Docker
+
+Open one terminal:
+
+```
+make run
+```
+
+That's it.
+
+If you would like to allow visualization across docker container, open another terminal and type:
+
+```
+xhost +
+```
+
+
+### Install without Docker
+
 Install Segment Anything:
 
 ```bash


### PR DESCRIPTION
# Summary

- [X] Add docker support
- [X] Add a Makefile to launch an environment with one-line of code
- [X] Updated Readme 
- [X] add .idea/ to .gitignore

# How this is tested 

Tested on the following environment:
- Ubuntu 22.04
- 3070 GPU
- Host machine: Driver Version: 525.85.12
- Docker version 20.10.22
- Host machine CUDA version -- N/A (not needed), managed by the container

Just do `make run`.
