### PR TITLE
added support for automatic_label_demo.py without chatgpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ python automatic_label_demo.py \
   --device "cuda"
 ```
 
-- The pseudo labels and model prediction visualization will be saved in `output_dir` as follows:
 - When you don't have a paid Account for ChatGPT is also possible to use NLTK instead. Just don't include the ```openai_key``` Parameter when starting the Demo.
   - The Script will automatically download the necessary NLTK Data.
+- The pseudo labels and model prediction visualization will be saved in `output_dir` as follows:
 
 ![](./assets/automatic_label_output_demo3.jpg)
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ python automatic_label_demo.py \
 ```
 
 - The pseudo labels and model prediction visualization will be saved in `output_dir` as follows:
+- When you don't have a paid Account for ChatGPT is also possible to use NLTK instead. Just don't include the ```openai_key``` Parameter when starting the Demo.
 
 ![](./assets/automatic_label_output_demo3.jpg)
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ python automatic_label_demo.py \
 
 - The pseudo labels and model prediction visualization will be saved in `output_dir` as follows:
 - When you don't have a paid Account for ChatGPT is also possible to use NLTK instead. Just don't include the ```openai_key``` Parameter when starting the Demo.
+  - The Script will automatically download the necessary NLTK Data.
 
 ![](./assets/automatic_label_output_demo3.jpg)
 

--- a/automatic_label_demo.py
+++ b/automatic_label_demo.py
@@ -7,6 +7,7 @@ import json
 import torch
 import torchvision
 from PIL import Image, ImageDraw, ImageFont
+import nltk
 
 # Grounding DINO
 import GroundingDINO.groundingdino.datasets.transforms as T
@@ -55,18 +56,24 @@ def generate_caption(raw_image, device):
 
 
 def generate_tags(caption, split=',', max_tokens=100, model="gpt-3.5-turbo"):
-    prompt = [
-        {
-            'role': 'system',
-            'content': 'Extract the unique nouns in the caption. Remove all the adjectives. ' + \
-                       f'List the nouns in singular form. Split them by "{split} ". ' + \
-                       f'Caption: {caption}.'
-        }
-    ]
-    response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
-    reply = response['choices'][0]['message']['content']
-    # sometimes return with "noun: xxx, xxx, xxx"
-    tags = reply.split(':')[-1].strip()
+    lemma = nltk.wordnet.WordNetLemmatizer()
+    if openai_key:
+        prompt = [
+            {
+                'role': 'system',
+                'content': 'Extract the unique nouns in the caption. Remove all the adjectives. ' + \
+                           f'List the nouns in singular form. Split them by "{split} ". ' + \
+                           f'Caption: {caption}.'
+            }
+        ]
+        response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+        reply = response['choices'][0]['message']['content']
+        # sometimes return with "noun: xxx, xxx, xxx"
+        tags = reply.split(':')[-1].strip()
+    else:
+        tags_list = [word for (word, pos) in nltk.pos_tag(nltk.word_tokenize(caption)) if pos[0] == 'N']
+        tags_lemma = [lemma.lemmatize(w) for w in tags_list]
+        tags = ', '.join(map(str, tags_lemma))
     return tags
 
 
@@ -78,19 +85,20 @@ def check_caption(caption, pred_phrases, max_tokens=100, model="gpt-3.5-turbo"):
     object_num = ', '.join(object_num)
     print(f"Correct object number: {object_num}")
 
-    prompt = [
-        {
-            'role': 'system',
-            'content': 'Revise the number in the caption if it is wrong. ' + \
-                       f'Caption: {caption}. ' + \
-                       f'True object number: {object_num}. ' + \
-                       'Only give the revised caption: '
-        }
-    ]
-    response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
-    reply = response['choices'][0]['message']['content']
-    # sometimes return with "Caption: xxx, xxx, xxx"
-    caption = reply.split(':')[-1].strip()
+    if openai_key:
+        prompt = [
+            {
+                'role': 'system',
+                'content': 'Revise the number in the caption if it is wrong. ' + \
+                           f'Caption: {caption}. ' + \
+                           f'True object number: {object_num}. ' + \
+                           'Only give the revised caption: '
+            }
+        ]
+        response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+        reply = response['choices'][0]['message']['content']
+        # sometimes return with "Caption: xxx, xxx, xxx"
+        caption = reply.split(':')[-1].strip()
     return caption
 
 
@@ -201,7 +209,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--input_image", type=str, required=True, help="path to image file")
     parser.add_argument("--split", default=",", type=str, help="split for text prompt")
-    parser.add_argument("--openai_key", type=str, required=True, help="key for chatgpt")
+    parser.add_argument("--openai_key", type=str, help="key for chatgpt")
     parser.add_argument("--openai_proxy", default=None, type=str, help="proxy for chatgpt")
     parser.add_argument(
         "--output_dir", "-o", type=str, default="outputs", required=True, help="output directory"

--- a/automatic_label_demo.py
+++ b/automatic_label_demo.py
@@ -71,6 +71,7 @@ def generate_tags(caption, split=',', max_tokens=100, model="gpt-3.5-turbo"):
         # sometimes return with "noun: xxx, xxx, xxx"
         tags = reply.split(':')[-1].strip()
     else:
+        nltk.download(['punkt', 'averaged_perceptron_tagger', 'wordnet'])
         tags_list = [word for (word, pos) in nltk.pos_tag(nltk.word_tokenize(caption)) if pos[0] == 'N']
         tags_lemma = [lemma.lemmatize(w) for w in tags_list]
         tags = ', '.join(map(str, tags_lemma))

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ torch
 torchvision
 transformers
 yapf
+nltk


### PR DESCRIPTION
Hi! Since it's only possible to use ```automatic_label_demo.py``` with a paid OpenAI Account I implemented a method to use the functionality without ChatGPT.
To achieve this I used NLTK to extract nouns from the caption. I also used a Lemmatizer to improve the produced tags.

Your implementation with ChatGPT:
![automatic_label_output_demo3](https://user-images.githubusercontent.com/40420097/232302683-18e31322-0a04-46dd-8bb8-e80dd4b78022.jpg)

My implementation **without** ChatGPT:
![automatic_label_output](https://user-images.githubusercontent.com/40420097/232303311-07d1cb7a-3758-4738-8f22-93a59eb609b5.jpg)

I implemented the feature in way to let the user choose if they want to use ChatGPT or not. If the script get startet without the ```openai_key``` by default NLTK will be used. If the user provides a valid key ChatGPT will be used.

Let me know what you think about this feature.