### PR TITLE
Hotfix/setup

### DIFF
--- a/GroundingDINO/setup.py
+++ b/GroundingDINO/setup.py
@@ -69,8 +69,8 @@ def get_extensions():
     # It solves https://github.com/IDEA-Research/Grounded-Segment-Anything/issues/53
     # and https://github.com/IDEA-Research/Grounded-Segment-Anything/issues/84 when running
     # inside a Docker container.
-    am_i_docker = os.environ.get('AM_I_DOCKER').casefold() in ['true', '1', 't']
-    use_cuda = os.environ.get('BUILD_WITH_CUDA').casefold() in ['true', '1', 't']
+    am_i_docker = os.environ.get('AM_I_DOCKER', '').casefold() in ['true', '1', 't']
+    use_cuda = os.environ.get('BUILD_WITH_CUDA', '').casefold() in ['true', '1', 't']
 
     extension = CppExtension
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,16 @@
 # This solves https://github.com/IDEA-Research/Grounded-Segment-Anything/issues/53
 # and https://github.com/IDEA-Research/Grounded-Segment-Anything/issues/84
 # when running in Docker
-NVCC_VERSION := $(shell nvcc --version | grep -oP 'release \K[0-9.]+')
-USE_CUDA := $(shell echo "$(NVCC_VERSION) > 11" | bc -l)
+# Check if nvcc is installed
+NVCC := $(shell which nvcc)
+ifeq ($(NVCC),)
+	# NVCC not found
+	USE_CUDA := 0
+	NVCC_VERSION := "not installed"
+else
+	NVCC_VERSION := $(shell nvcc --version | grep -oP 'release \K[0-9.]+')
+	USE_CUDA := $(shell echo "$(NVCC_VERSION) > 11" | bc -l)
+endif
 
 # Add the list of supported ARCHs
 ifeq ($(USE_CUDA), 1)


### PR DESCRIPTION
If AM_I_DOCKER and BUILD_WITH_CUDA are not set, the build will fail, to solve this I'll return an empty string if these variables are not set.

Also if NVCC is not installed we will disable CUDA build in the Docker.