### PR TITLE
Update installation method of RAM/Tag2Text

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,3 @@
 [submodule "VISAM"]
 	path = VISAM
 	url = https://github.com/BingfengYan/VISAM
-[submodule "Tag2Text"]
-	path = Tag2Text
-	url = https://github.com/xinyu1205/Tag2Text.git

--- a/README.md
+++ b/README.md
@@ -182,8 +182,9 @@ cd grounded-sam-osx && bash install.sh
 Install RAM & Tag2Text:
 
 ```bash
-git submodule update --init --recursive
-cd Tag2Text && pip install -r requirements.txt
+git clone https://github.com/xinyu1205/recognize-anything.git
+pip install -r ./recognize-anything/requirements.txt
+pip install -e ./recognize-anything/
 ```
 
 The following optional dependencies are necessary for mask post-processing, saving masks in COCO format, the example notebooks, and exporting the model in ONNX format. `jupyter` is also required to run the example notebooks.
@@ -454,7 +455,6 @@ git submodule update
 wget https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth
 wget https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth
 
-cd Tag2Text
 wget https://huggingface.co/spaces/xinyu1205/Tag2Text/resolve/main/ram_swin_large_14m.pth
 wget https://huggingface.co/spaces/xinyu1205/Tag2Text/resolve/main/tag2text_swin_14m.pth
 ```
@@ -464,7 +464,7 @@ wget https://huggingface.co/spaces/xinyu1205/Tag2Text/resolve/main/tag2text_swin
 export CUDA_VISIBLE_DEVICES=0
 python automatic_label_ram_demo.py \
   --config GroundingDINO/groundingdino/config/GroundingDINO_SwinT_OGC.py \
-  --ram_checkpoint ./Tag2Text/ram_swin_large_14m.pth \
+  --ram_checkpoint ram_swin_large_14m.pth \
   --grounded_checkpoint groundingdino_swint_ogc.pth \
   --sam_checkpoint sam_vit_h_4b8939.pth \
   --input_image assets/demo9.jpg \
@@ -481,7 +481,7 @@ python automatic_label_ram_demo.py \
 export CUDA_VISIBLE_DEVICES=0
 python automatic_label_tag2text_demo.py \
   --config GroundingDINO/groundingdino/config/GroundingDINO_SwinT_OGC.py \
-  --tag2text_checkpoint ./Tag2Text/tag2text_swin_14m.pth \
+  --tag2text_checkpoint tag2text_swin_14m.pth \
   --grounded_checkpoint groundingdino_swint_ogc.pth \
   --sam_checkpoint sam_vit_h_4b8939.pth \
   --input_image assets/demo9.jpg \

--- a/automatic_label_ram_demo.py
+++ b/automatic_label_ram_demo.py
@@ -24,10 +24,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # Recognize Anything Model & Tag2Text
-import sys
-sys.path.append('Tag2Text')
-from Tag2Text.models import tag2text
-from Tag2Text import inference_ram
+from ram.models import ram
+from ram import inference_ram
 import torchvision.transforms as TS
 
 # ChatGPT or nltk is required when using tags_chineses
@@ -244,7 +242,7 @@ if __name__ == "__main__":
                 ])
     
     # load model
-    ram_model = tag2text.ram(pretrained=ram_checkpoint,
+    ram_model = ram(pretrained=ram_checkpoint,
                                         image_size=384,
                                         vit='swin_l')
     # threshold for tagging
@@ -256,7 +254,7 @@ if __name__ == "__main__":
                     (384, 384))
     raw_image  = transform(raw_image).unsqueeze(0).to(device)
 
-    res = inference_ram.inference(raw_image , ram_model)
+    res = inference_ram(raw_image , ram_model)
 
     # Currently ", " is better for detecting single tags
     # while ". " is a little worse in some case

--- a/automatic_label_simple_demo.py
+++ b/automatic_label_simple_demo.py
@@ -29,7 +29,7 @@ SAM_ENCODER_VERSION = "vit_h"
 SAM_CHECKPOINT_PATH = "./sam_vit_h_4b8939.pth"
 
 TAG2TEXT_CHECKPOINT_PATH = "./tag2text_swin_14m.pth"
-RAM_CHECKPOINT_PATH = "./Tag2Text/ram_swin_large_14m.pth"
+RAM_CHECKPOINT_PATH = "./ram_swin_large_14m.pth"
 
 TAG2TEXT_THRESHOLD = 0.64
 BOX_THRESHOLD = 0.2

--- a/automatic_label_simple_demo.py
+++ b/automatic_label_simple_demo.py
@@ -10,11 +10,10 @@ from groundingdino.util.inference import Model
 from segment_anything import sam_model_registry, SamPredictor
 
 # Tag2Text
-import sys
-sys.path.append('Tag2Text')
-from Tag2Text.models import tag2text
-# from Tag2Text import inference
-from Tag2Text import inference_ram
+# from ram.models import tag2text_caption
+from ram.models import ram
+# from ram import inference_tag2text
+from ram import inference_ram
 import torchvision
 import torchvision.transforms as TS
 
@@ -63,7 +62,7 @@ DELETE_TAG_INDEX = []  # filter out attributes and action which are difficult to
 for idx in range(3012, 3429):
     DELETE_TAG_INDEX.append(idx)
 
-# tag2text_model = tag2text.tag2text_caption(
+# tag2text_model = tag2text_caption(
 #     pretrained=TAG2TEXT_CHECKPOINT_PATH,
 #     image_size=384,
 #     vit='swin_b',
@@ -75,7 +74,7 @@ for idx in range(3012, 3429):
 # tag2text_model.eval()
 # tag2text_model = tag2text_model.to(DEVICE)
 
-ram_model = tag2text.ram(pretrained=RAM_CHECKPOINT_PATH,
+ram_model = ram(pretrained=RAM_CHECKPOINT_PATH,
                                         image_size=384,
                                         vit='swin_l')
 ram_model.eval()
@@ -89,8 +88,8 @@ image_pillow = image_pillow.resize((384, 384))
 image_pillow = transform(image_pillow).unsqueeze(0).to(DEVICE)
 
 specified_tags='None'
-# res = inference.inference(image_pillow , tag2text_model, specified_tags)
-res = inference_ram.inference(image_pillow , ram_model)
+# res = inference_tag2text(image_pillow , tag2text_model, specified_tags)
+res = inference_ram(image_pillow , ram_model)
 
 # Currently ", " is better for detecting single tags
 # while ". " is a little worse in some case

--- a/automatic_label_tag2text_demo.py
+++ b/automatic_label_tag2text_demo.py
@@ -22,10 +22,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # Tag2Text
-import sys
-sys.path.append('Tag2Text')
-from Tag2Text.models import tag2text
-from Tag2Text import inference_tag2text
+from ram.models import tag2text_caption
+from ram import inference_tag2text
 import torchvision.transforms as TS
 
 # ChatGPT or nltk is required when using captions
@@ -274,7 +272,7 @@ if __name__ == "__main__":
 
     specified_tags='None'
     # load model
-    tag2text_model = tag2text.tag2text_caption(pretrained=tag2text_checkpoint,
+    tag2text_model = tag2text_caption(pretrained=tag2text_checkpoint,
                                         image_size=384,
                                         vit='swin_b',
                                         delete_tag_index=delete_tag_index)
@@ -288,7 +286,7 @@ if __name__ == "__main__":
                     (384, 384))
     raw_image  = transform(raw_image).unsqueeze(0).to(device)
 
-    res = inference_tag2text.inference(raw_image , tag2text_model, specified_tags)
+    res = inference_tag2text(raw_image , tag2text_model, specified_tags)
 
     # Currently ", " is better for detecting single tags
     # while ". " is a little worse in some case

--- a/predict.py
+++ b/predict.py
@@ -36,10 +36,7 @@ from GroundingDINO.groundingdino.util.utils import (
 # segment anything
 from segment_anything import build_sam, build_sam_hq, SamPredictor
 
-import sys
-
-sys.path.append("Tag2Text")
-from models.tag2text import ram
+from ram.models import ram
 
 
 class ModelOutput(BaseModel):


### PR DESCRIPTION
RAM/Tag2Text code now support packaging with setuptools, and some module paths (not interface) slighly changed when adapting old codes.
This PR:
1. Removes old `Tag2Text` submodule, and let you install RAM/Tag2Text with `pip install` instead.
2. Update relevant code in demo scripts.