### PR TITLE
Add support for Azure OpenAI, Palm, Replicate, Sagemaker (100+LLMs) - using litellm

### DIFF
--- a/automatic_label_demo.py
+++ b/automatic_label_demo.py
@@ -8,6 +8,7 @@ import torch
 import torchvision
 from PIL import Image, ImageDraw, ImageFont
 import nltk
+import litellm
 
 # Grounding DINO
 import GroundingDINO.groundingdino.datasets.transforms as T
@@ -66,7 +67,7 @@ def generate_tags(caption, split=',', max_tokens=100, model="gpt-3.5-turbo"):
                            f'Caption: {caption}.'
             }
         ]
-        response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+        response = litellm.completion(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
         reply = response['choices'][0]['message']['content']
         # sometimes return with "noun: xxx, xxx, xxx"
         tags = reply.split(':')[-1].strip()
@@ -96,7 +97,7 @@ def check_caption(caption, pred_phrases, max_tokens=100, model="gpt-3.5-turbo"):
                            'Only give the revised caption: '
             }
         ]
-        response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+        response = litellm.completion(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
         reply = response['choices'][0]['message']['content']
         # sometimes return with "Caption: xxx, xxx, xxx"
         caption = reply.split(':')[-1].strip()

--- a/automatic_label_ram_demo.py
+++ b/automatic_label_ram_demo.py
@@ -6,6 +6,7 @@ import json
 import torch
 import torchvision
 from PIL import Image
+import litellm
 
 # Grounding DINO
 import GroundingDINO.groundingdino.datasets.transforms as T
@@ -67,7 +68,7 @@ def check_tags_chinese(tags_chinese, pred_phrases, max_tokens=100, model="gpt-3.
                            'Only give the revised tags_chinese: '
             }
         ]
-        response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+        response = litellm.completion(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
         reply = response['choices'][0]['message']['content']
         # sometimes return with "tags_chinese: xxx, xxx, xxx"
         tags_chinese = reply.split(':')[-1].strip()

--- a/automatic_label_tag2text_demo.py
+++ b/automatic_label_tag2text_demo.py
@@ -7,6 +7,7 @@ import json
 import torch
 import torchvision
 from PIL import Image, ImageDraw, ImageFont
+import litellm
 
 # Grounding DINO
 import GroundingDINO.groundingdino.datasets.transforms as T
@@ -69,7 +70,7 @@ def generate_tags(caption, split=',', max_tokens=100, model="gpt-3.5-turbo"):
                            f'Caption: {caption}.'
             }
         ]
-        response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+        response = litellm.completion(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
         reply = response['choices'][0]['message']['content']
         # sometimes return with "noun: xxx, xxx, xxx"
         tags = reply.split(':')[-1].strip()
@@ -99,7 +100,7 @@ def check_caption(caption, pred_phrases, max_tokens=100, model="gpt-3.5-turbo"):
                            'Only give the revised caption: '
             }
         ]
-        response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+        response = litellm.completion(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
         reply = response['choices'][0]['message']['content']
         # sometimes return with "Caption: xxx, xxx, xxx"
         caption = reply.split(':')[-1].strip()

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -5,6 +5,7 @@ from scipy import ndimage
 
 import gradio as gr
 import argparse
+import litellm
 
 import numpy as np
 import torch
@@ -73,7 +74,7 @@ def generate_tags(caption, split=',', max_tokens=100, model="gpt-3.5-turbo", ope
                        f'Caption: {caption}.'
         }
     ]
-    response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+    response = litellm.completion(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
     reply = response['choices'][0]['message']['content']
     # sometimes return with "noun: xxx, xxx, xxx"
     tags = reply.split(':')[-1].strip()

--- a/grounded_sam_whisper_inpainting_demo.py
+++ b/grounded_sam_whisper_inpainting_demo.py
@@ -5,6 +5,7 @@ from warnings import warn
 import numpy as np
 import torch
 from PIL import Image, ImageDraw, ImageFont
+import litellm
 
 # Grounding DINO
 import GroundingDINO.groundingdino.datasets.transforms as T
@@ -144,7 +145,7 @@ def filter_prompts_with_chatgpt(caption, max_tokens=100, model="gpt-3.5-turbo"):
                        f'Given caption: {caption}.'
         }
     ]
-    response = openai.ChatCompletion.create(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
+    response = litellm.completion(model=model, messages=prompt, temperature=0.6, max_tokens=max_tokens)
     reply = response['choices'][0]['message']['content']
     try:
         det_prompt, inpaint_prompt = reply.split('\n')[0].split(':')[-1].strip(), reply.split('\n')[1].split(':')[-1].strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ transformers
 yapf
 nltk
 fairscale
+litellm


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```