### PR TITLE
Support EdgeSAM in Grounded-SAM

### DIFF
--- a/EfficientSAM/EdgeSAM/common.py
+++ b/EfficientSAM/EdgeSAM/common.py
@@ -1,0 +1,118 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from typing import Type
+
+
+class MLPBlock(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int,
+        mlp_dim: int,
+        act: Type[nn.Module] = nn.GELU,
+    ) -> None:
+        super().__init__()
+        self.lin1 = nn.Linear(embedding_dim, mlp_dim)
+        self.lin2 = nn.Linear(mlp_dim, embedding_dim)
+        self.act = act()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.lin2(self.act(self.lin1(x)))
+
+
+# From https://github.com/facebookresearch/detectron2/blob/main/detectron2/layers/batch_norm.py # noqa
+# Itself from https://github.com/facebookresearch/ConvNeXt/blob/d1fa8f6fef0a165b27399986cc2bdacc92777e40/models/convnext.py#L119  # noqa
+class LayerNorm2d(nn.Module):
+    def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(num_channels))
+        self.bias = nn.Parameter(torch.zeros(num_channels))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        u = x.mean(1, keepdim=True)
+        s = (x - u).pow(2).mean(1, keepdim=True)
+        x = (x - u) / torch.sqrt(s + self.eps)
+        x = self.weight[:, None, None] * x + self.bias[:, None, None]
+        return x
+
+
+def val2list(x: list or tuple or any, repeat_time=1) -> list:
+    if isinstance(x, (list, tuple)):
+        return list(x)
+    return [x for _ in range(repeat_time)]
+
+
+def val2tuple(x: list or tuple or any, min_len: int = 1, idx_repeat: int = -1) -> tuple:
+    x = val2list(x)
+
+    # repeat elements if necessary
+    if len(x) > 0:
+        x[idx_repeat:idx_repeat] = [x[idx_repeat] for _ in range(min_len - len(x))]
+
+    return tuple(x)
+
+
+def list_sum(x: list) -> any:
+    return x[0] if len(x) == 1 else x[0] + list_sum(x[1:])
+
+
+def resize(
+        x: torch.Tensor,
+        size: any or None = None,
+        scale_factor=None,
+        mode: str = "bicubic",
+        align_corners: bool or None = False,
+) -> torch.Tensor:
+    if mode in ["bilinear", "bicubic"]:
+        return F.interpolate(
+            x,
+            size=size,
+            scale_factor=scale_factor,
+            mode=mode,
+            align_corners=align_corners,
+        )
+    elif mode in ["nearest", "area"]:
+        return F.interpolate(x, size=size, scale_factor=scale_factor, mode=mode)
+    else:
+        raise NotImplementedError(f"resize(mode={mode}) not implemented.")
+
+
+class UpSampleLayer(nn.Module):
+    def __init__(
+            self,
+            mode="bicubic",
+            size=None,
+            factor=2,
+            align_corners=False,
+    ):
+        super(UpSampleLayer, self).__init__()
+        self.mode = mode
+        self.size = val2list(size, 2) if size is not None else None
+        self.factor = None if self.size is not None else factor
+        self.align_corners = align_corners
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return resize(x, self.size, self.factor, self.mode, self.align_corners)
+
+
+class OpSequential(nn.Module):
+    def __init__(self, op_list):
+        super(OpSequential, self).__init__()
+        valid_op_list = []
+        for op in op_list:
+            if op is not None:
+                valid_op_list.append(op)
+        self.op_list = nn.ModuleList(valid_op_list)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for op in self.op_list:
+            x = op(x)
+        return x

--- a/EfficientSAM/EdgeSAM/rep_vit.py
+++ b/EfficientSAM/EdgeSAM/rep_vit.py
@@ -1,0 +1,370 @@
+import torch.nn as nn
+from EdgeSAM.common import LayerNorm2d, UpSampleLayer, OpSequential
+
+__all__ = ['rep_vit_m1', 'rep_vit_m2', 'rep_vit_m3', 'RepViT']
+
+m1_cfgs = [
+    # k, t, c, SE, HS, s
+    [3, 2, 48, 1, 0, 1],
+    [3, 2, 48, 0, 0, 1],
+    [3, 2, 48, 0, 0, 1],
+    [3, 2, 96, 0, 0, 2],
+    [3, 2, 96, 1, 0, 1],
+    [3, 2, 96, 0, 0, 1],
+    [3, 2, 96, 0, 0, 1],
+    [3, 2, 192, 0, 1, 2],
+    [3, 2, 192, 1, 1, 1],
+    [3, 2, 192, 0, 1, 1],
+    [3, 2, 192, 1, 1, 1],
+    [3, 2, 192, 0, 1, 1],
+    [3, 2, 192, 1, 1, 1],
+    [3, 2, 192, 0, 1, 1],
+    [3, 2, 192, 1, 1, 1],
+    [3, 2, 192, 0, 1, 1],
+    [3, 2, 192, 1, 1, 1],
+    [3, 2, 192, 0, 1, 1],
+    [3, 2, 192, 1, 1, 1],
+    [3, 2, 192, 0, 1, 1],
+    [3, 2, 192, 1, 1, 1],
+    [3, 2, 192, 0, 1, 1],
+    [3, 2, 192, 0, 1, 1],
+    [3, 2, 384, 0, 1, 2],
+    [3, 2, 384, 1, 1, 1],
+    [3, 2, 384, 0, 1, 1]
+]
+
+m2_cfgs = [
+    # k, t, c, SE, HS, s
+    [3, 2, 64, 1, 0, 1],
+    [3, 2, 64, 0, 0, 1],
+    [3, 2, 64, 0, 0, 1],
+    [3, 2, 128, 0, 0, 2],
+    [3, 2, 128, 1, 0, 1],
+    [3, 2, 128, 0, 0, 1],
+    [3, 2, 128, 0, 0, 1],
+    [3, 2, 256, 0, 1, 2],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 512, 0, 1, 2],
+    [3, 2, 512, 1, 1, 1],
+    [3, 2, 512, 0, 1, 1]
+]
+
+m3_cfgs = [
+    # k, t, c, SE, HS, s
+    [3, 2, 64, 1, 0, 1],
+    [3, 2, 64, 0, 0, 1],
+    [3, 2, 64, 1, 0, 1],
+    [3, 2, 64, 0, 0, 1],
+    [3, 2, 64, 0, 0, 1],
+    [3, 2, 128, 0, 0, 2],
+    [3, 2, 128, 1, 0, 1],
+    [3, 2, 128, 0, 0, 1],
+    [3, 2, 128, 1, 0, 1],
+    [3, 2, 128, 0, 0, 1],
+    [3, 2, 128, 0, 0, 1],
+    [3, 2, 256, 0, 1, 2],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 1, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 256, 0, 1, 1],
+    [3, 2, 512, 0, 1, 2],
+    [3, 2, 512, 1, 1, 1],
+    [3, 2, 512, 0, 1, 1]
+]
+
+
+def _make_divisible(v, divisor, min_value=None):
+    """
+    This function is taken from the original tf repo.
+    It ensures that all layers have a channel number that is divisible by 8
+    It can be seen here:
+    https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet/mobilenet.py
+    :param v:
+    :param divisor:
+    :param min_value:
+    :return:
+    """
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    # Make sure that round down does not go down by more than 10%.
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+
+from timm.models.layers import SqueezeExcite
+
+import torch
+
+
+class Conv2d_BN(torch.nn.Sequential):
+    def __init__(self, a, b, ks=1, stride=1, pad=0, dilation=1,
+                 groups=1, bn_weight_init=1, resolution=-10000):
+        super().__init__()
+        self.add_module('c', torch.nn.Conv2d(
+            a, b, ks, stride, pad, dilation, groups, bias=False))
+        self.add_module('bn', torch.nn.BatchNorm2d(b))
+        torch.nn.init.constant_(self.bn.weight, bn_weight_init)
+        torch.nn.init.constant_(self.bn.bias, 0)
+
+    @torch.no_grad()
+    def fuse(self):
+        c, bn = self._modules.values()
+        w = bn.weight / (bn.running_var + bn.eps) ** 0.5
+        w = c.weight * w[:, None, None, None]
+        b = bn.bias - bn.running_mean * bn.weight / \
+            (bn.running_var + bn.eps) ** 0.5
+        m = torch.nn.Conv2d(w.size(1) * self.c.groups, w.size(
+            0), w.shape[2:], stride=self.c.stride, padding=self.c.padding, dilation=self.c.dilation,
+                            groups=self.c.groups,
+                            device=c.weight.device)
+        m.weight.data.copy_(w)
+        m.bias.data.copy_(b)
+        return m
+
+
+class Residual(torch.nn.Module):
+    def __init__(self, m, drop=0.):
+        super().__init__()
+        self.m = m
+        self.drop = drop
+
+    def forward(self, x):
+        if self.training and self.drop > 0:
+            return x + self.m(x) * torch.rand(x.size(0), 1, 1, 1,
+                                              device=x.device).ge_(self.drop).div(1 - self.drop).detach()
+        else:
+            return x + self.m(x)
+
+    @torch.no_grad()
+    def fuse(self):
+        if isinstance(self.m, Conv2d_BN):
+            m = self.m.fuse()
+            assert (m.groups == m.in_channels)
+            identity = torch.ones(m.weight.shape[0], m.weight.shape[1], 1, 1)
+            identity = torch.nn.functional.pad(identity, [1, 1, 1, 1])
+            m.weight += identity.to(m.weight.device)
+            return m
+        elif isinstance(self.m, torch.nn.Conv2d):
+            m = self.m
+            assert (m.groups != m.in_channels)
+            identity = torch.ones(m.weight.shape[0], m.weight.shape[1], 1, 1)
+            identity = torch.nn.functional.pad(identity, [1, 1, 1, 1])
+            m.weight += identity.to(m.weight.device)
+            return m
+        else:
+            return self
+
+
+class RepVGGDW(torch.nn.Module):
+    def __init__(self, ed) -> None:
+        super().__init__()
+        self.conv = Conv2d_BN(ed, ed, 3, 1, 1, groups=ed)
+        self.conv1 = Conv2d_BN(ed, ed, 1, 1, 0, groups=ed)
+        self.dim = ed
+
+    def forward(self, x):
+        return self.conv(x) + self.conv1(x) + x
+
+    @torch.no_grad()
+    def fuse(self):
+        conv = self.conv.fuse()
+        conv1 = self.conv1.fuse()
+
+        conv_w = conv.weight
+        conv_b = conv.bias
+        conv1_w = conv1.weight
+        conv1_b = conv1.bias
+
+        conv1_w = torch.nn.functional.pad(conv1_w, [1, 1, 1, 1])
+
+        identity = torch.nn.functional.pad(torch.ones(conv1_w.shape[0], conv1_w.shape[1], 1, 1, device=conv1_w.device),
+                                           [1, 1, 1, 1])
+
+        final_conv_w = conv_w + conv1_w + identity
+        final_conv_b = conv_b + conv1_b
+
+        conv.weight.data.copy_(final_conv_w)
+        conv.bias.data.copy_(final_conv_b)
+        return conv
+
+
+class RepViTBlock(nn.Module):
+    def __init__(self, inp, hidden_dim, oup, kernel_size, stride, use_se, use_hs, skip_downsample=False):
+        super(RepViTBlock, self).__init__()
+        assert stride in [1, 2]
+
+        self.identity = stride == 1 and inp == oup
+        assert (hidden_dim == 2 * inp)
+
+        if stride == 2:
+            if skip_downsample:
+                stride = 1
+            self.token_mixer = nn.Sequential(
+                Conv2d_BN(inp, inp, kernel_size, stride, (kernel_size - 1) // 2, groups=inp),
+                SqueezeExcite(inp, 0.25) if use_se else nn.Identity(),
+                Conv2d_BN(inp, oup, ks=1, stride=1, pad=0)
+            )
+            self.channel_mixer = Residual(nn.Sequential(
+                # pw
+                Conv2d_BN(oup, 2 * oup, 1, 1, 0),
+                nn.GELU() if use_hs else nn.GELU(),
+                # pw-linear
+                Conv2d_BN(2 * oup, oup, 1, 1, 0, bn_weight_init=0),
+            ))
+        else:
+            assert (self.identity)
+            self.token_mixer = nn.Sequential(
+                RepVGGDW(inp),
+                SqueezeExcite(inp, 0.25) if use_se else nn.Identity(),
+            )
+            self.channel_mixer = Residual(nn.Sequential(
+                # pw
+                Conv2d_BN(inp, hidden_dim, 1, 1, 0),
+                nn.GELU() if use_hs else nn.GELU(),
+                # pw-linear
+                Conv2d_BN(hidden_dim, oup, 1, 1, 0, bn_weight_init=0),
+            ))
+
+    def forward(self, x):
+        return self.channel_mixer(self.token_mixer(x))
+
+
+from timm.models.vision_transformer import trunc_normal_
+
+
+class BN_Linear(torch.nn.Sequential):
+    def __init__(self, a, b, bias=True, std=0.02):
+        super().__init__()
+        self.add_module('bn', torch.nn.BatchNorm1d(a))
+        self.add_module('l', torch.nn.Linear(a, b, bias=bias))
+        trunc_normal_(self.l.weight, std=std)
+        if bias:
+            torch.nn.init.constant_(self.l.bias, 0)
+
+    @torch.no_grad()
+    def fuse(self):
+        bn, l = self._modules.values()
+        w = bn.weight / (bn.running_var + bn.eps) ** 0.5
+        b = bn.bias - self.bn.running_mean * \
+            self.bn.weight / (bn.running_var + bn.eps) ** 0.5
+        w = l.weight * w[None, :]
+        if l.bias is None:
+            b = b @ self.l.weight.T
+        else:
+            b = (l.weight @ b[:, None]).view(-1) + self.l.bias
+        m = torch.nn.Linear(w.size(1), w.size(0), device=l.weight.device)
+        m.weight.data.copy_(w)
+        m.bias.data.copy_(b)
+        return m
+
+
+class RepViT(nn.Module):
+    arch_settings = {
+        'm1': m1_cfgs,
+        'm2': m2_cfgs,
+        'm3': m3_cfgs
+    }
+
+    def __init__(self, arch, img_size=1024, upsample_mode='bicubic'):
+        super(RepViT, self).__init__()
+        # setting of inverted residual blocks
+        self.cfgs = self.arch_settings[arch]
+        self.img_size = img_size
+
+        # building first layer
+        input_channel = self.cfgs[0][2]
+        patch_embed = torch.nn.Sequential(Conv2d_BN(3, input_channel // 2, 3, 2, 1), torch.nn.GELU(),
+                                          Conv2d_BN(input_channel // 2, input_channel, 3, 2, 1))
+        layers = [patch_embed]
+        # building inverted residual blocks
+        block = RepViTBlock
+        self.stage_idx = []
+        prev_c = input_channel
+        for idx, (k, t, c, use_se, use_hs, s) in enumerate(self.cfgs):
+            output_channel = _make_divisible(c, 8)
+            exp_size = _make_divisible(input_channel * t, 8)
+            skip_downsample = False
+            if c != prev_c:
+                self.stage_idx.append(idx - 1)
+                prev_c = c
+            layers.append(block(input_channel, exp_size, output_channel, k, s, use_se, use_hs, skip_downsample))
+            input_channel = output_channel
+        self.stage_idx.append(idx)
+        self.features = nn.ModuleList(layers)
+
+        stage2_channels = _make_divisible(self.cfgs[self.stage_idx[2]][2], 8)
+        stage3_channels = _make_divisible(self.cfgs[self.stage_idx[3]][2], 8)
+        self.fuse_stage2 = nn.Conv2d(stage2_channels, 256, kernel_size=1, bias=False)
+        self.fuse_stage3 = OpSequential([
+            nn.Conv2d(stage3_channels, 256, kernel_size=1, bias=False),
+            UpSampleLayer(factor=2, mode=upsample_mode),
+        ])
+
+        self.neck = nn.Sequential(
+            nn.Conv2d(256, 256, kernel_size=1, bias=False),
+            LayerNorm2d(256),
+            nn.Conv2d(256, 256, kernel_size=3, padding=1, bias=False),
+            LayerNorm2d(256),
+        )
+
+    def forward(self, x):
+        counter = 0
+        output_dict = dict()
+        # patch_embed
+        x = self.features[0](x)
+        output_dict['stem'] = x
+        # stages
+        for idx, f in enumerate(self.features[1:]):
+            x = f(x)
+            if idx in self.stage_idx:
+                output_dict[f'stage{counter}'] = x
+                counter += 1
+
+        x = self.fuse_stage2(output_dict['stage2']) + self.fuse_stage3(output_dict['stage3'])
+
+        x = self.neck(x)
+        # hack this place because we modified the predictor of SAM for HQ-SAM in
+        # segment_anything/segment_anything/predictor.py line 91 to return intern features of the backbone
+        # self.features, self.interm_features = self.model.image_encoder(input_image)
+        return x, None
+
+
+def rep_vit_m1(img_size=1024, **kwargs):
+    return RepViT('m1', img_size, **kwargs)
+
+
+def rep_vit_m2(img_size=1024, **kwargs):
+    return RepViT('m2', img_size, **kwargs)
+
+
+def rep_vit_m3(img_size=1024, **kwargs):
+    return RepViT('m3', img_size, **kwargs)

--- a/EfficientSAM/EdgeSAM/setup_edge_sam.py
+++ b/EfficientSAM/EdgeSAM/setup_edge_sam.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from functools import partial
+
+from segment_anything.modeling import ImageEncoderViT, MaskDecoder, PromptEncoder, Sam, TwoWayTransformer
+from EdgeSAM.rep_vit import RepViT
+
+
+prompt_embed_dim = 256
+image_size = 1024
+vit_patch_size = 16
+image_embedding_size = image_size // vit_patch_size
+
+
+def build_edge_sam(checkpoint=None, upsample_mode="bicubic"):
+    image_encoder = RepViT(
+        arch="m1",
+        img_size=image_size,
+        upsample_mode=upsample_mode
+    )
+    return _build_sam(image_encoder, checkpoint)
+
+
+sam_model_registry = {
+    "default": build_edge_sam,
+    "edge_sam": build_edge_sam,
+}
+
+def _build_sam_encoder(
+    encoder_embed_dim,
+    encoder_depth,
+    encoder_num_heads,
+    encoder_global_attn_indexes,
+):
+    image_encoder = ImageEncoderViT(
+        depth=encoder_depth,
+        embed_dim=encoder_embed_dim,
+        img_size=image_size,
+        mlp_ratio=4,
+        norm_layer=partial(torch.nn.LayerNorm, eps=1e-6),
+        num_heads=encoder_num_heads,
+        patch_size=vit_patch_size,
+        qkv_bias=True,
+        use_rel_pos=True,
+        global_attn_indexes=encoder_global_attn_indexes,
+        window_size=14,
+        out_chans=prompt_embed_dim,
+    )
+    return image_encoder
+
+
+def _build_sam(
+    image_encoder,
+    checkpoint=None,
+):
+    sam = Sam(
+        image_encoder=image_encoder,
+        prompt_encoder=PromptEncoder(
+            embed_dim=prompt_embed_dim,
+            image_embedding_size=(image_embedding_size, image_embedding_size),
+            input_image_size=(image_size, image_size),
+            mask_in_chans=16,
+        ),
+        mask_decoder=MaskDecoder(
+            num_multimask_outputs=3,
+            transformer=TwoWayTransformer(
+                depth=2,
+                embedding_dim=prompt_embed_dim,
+                mlp_dim=2048,
+                num_heads=8,
+            ),
+            transformer_dim=prompt_embed_dim,
+            iou_head_depth=3,
+            iou_head_hidden_dim=256,
+        ),
+        pixel_mean=[123.675, 116.28, 103.53],
+        pixel_std=[58.395, 57.12, 57.375],
+    )
+    sam.eval()
+    if checkpoint is not None:
+        with open(checkpoint, "rb") as f:
+            state_dict = torch.load(f, map_location="cpu")
+        sam.load_state_dict(state_dict)
+    return sam

--- a/EfficientSAM/README.md
+++ b/EfficientSAM/README.md
@@ -12,6 +12,7 @@ We're going to combine [Grounding-DINO](https://github.com/IDEA-Research/Groundi
 - [Run Grounded-MobileSAM Demo](#run-grounded-mobilesam-demo)
 - [Run Grounded-LightHQSAM Demo](#run-grounded-light-hqsam-demo)
 - [Run Grounded-EfficientSAM Demo](#run-grounded-efficient-sam-demo)
+- [Run Grounded-EdgeSAM Demo]()
 
 
 ### Installation
@@ -81,7 +82,7 @@ python EfficientSAM/grounded_mobile_sam.py --MOBILE_SAM_CHECKPOINT_PATH "./Effic
 
 | Input | Text | Output |
 |:---:|:---:|:---:|
-|![](/assets/demo2.jpg) | "The running dog" | ![](https://github.com/IDEA-Research/detrex-storage/blob/main/assets/grounded_sam/mobile_sam/grounded_mobile_sam_annotated_image.jpg?raw=true) |
+|![](/assets/demo2.jpg) | "the running dog" | ![](https://github.com/IDEA-Research/detrex-storage/blob/main/assets/grounded_sam/mobile_sam/grounded_mobile_sam_annotated_image.jpg?raw=true) |
 
 </div>
 
@@ -104,7 +105,7 @@ python EfficientSAM/grounded_light_hqsam.py
 
 | Input | Text | Output |
 |:---:|:---:|:---:|
-|![](/EfficientSAM/LightHQSAM/example_light_hqsam.png) | "Bench" | ![](/EfficientSAM/LightHQSAM/grounded_light_hqsam_annotated_image.jpg) |
+|![](/EfficientSAM/LightHQSAM/example_light_hqsam.png) | "bench" | ![](/EfficientSAM/LightHQSAM/grounded_light_hqsam_annotated_image.jpg) |
 
 </div>
 
@@ -127,6 +128,36 @@ python EfficientSAM/grounded_efficient_sam.py
 
 | Input | Text | Output |
 |:---:|:---:|:---:|
-|![](/EfficientSAM/LightHQSAM/example_light_hqsam.png) | "Bench" | ![](https://github.com/IDEA-Research/detrex-storage/blob/main/assets/grounded_sam/efficient_sam/grounded_efficient_sam_annotated_image.jpg?raw=true) |
+|![](/EfficientSAM/LightHQSAM/example_light_hqsam.png) | "bench" | ![](https://github.com/IDEA-Research/detrex-storage/blob/main/assets/grounded_sam/efficient_sam/grounded_efficient_sam_annotated_image.jpg?raw=true) |
 
 </div>
+
+
+### Run Grounded-Edge-SAM Demo
+
+- Download the pretrained [Edge-SAM](https://github.com/chongzhou96/EdgeSAM) checkpoint follow the [official instruction](https://github.com/chongzhou96/EdgeSAM?tab=readme-ov-file#usage-) as:
+
+```bash
+cd Grounded-Segment-Anything
+wget -P EfficientSAM/ https://huggingface.co/spaces/chongzhou/EdgeSAM/resolve/main/weights/edge_sam.pth
+wget -P EfficientSAM/ https://huggingface.co/spaces/chongzhou/EdgeSAM/resolve/main/weights/edge_sam_3x.pth
+```
+
+- Run the demo with the following script:
+
+```bash
+cd Grounded-Segment-Anything
+
+python EfficientSAM/grounded_edge_sam.py
+```
+
+- And the result will be saved as `./gronded_edge_sam_anontated_image.jpg` as:
+
+<div style="text-align: center">
+
+| Input | Text | Output |
+|:---:|:---:|:---:|
+|![](/EfficientSAM/LightHQSAM/example_light_hqsam.png) | "bench" | ![](https://github.com/IDEA-Research/detrex-storage/blob/main/assets/grounded_sam/edge_sam/grounded_edge_sam_annotated_image.jpg?raw=true) |
+
+</div>
+

--- a/EfficientSAM/README.md
+++ b/EfficientSAM/README.md
@@ -12,7 +12,7 @@ We're going to combine [Grounding-DINO](https://github.com/IDEA-Research/Groundi
 - [Run Grounded-MobileSAM Demo](#run-grounded-mobilesam-demo)
 - [Run Grounded-LightHQSAM Demo](#run-grounded-light-hqsam-demo)
 - [Run Grounded-EfficientSAM Demo](#run-grounded-efficient-sam-demo)
-- [Run Grounded-EdgeSAM Demo]()
+- [Run Grounded-EdgeSAM Demo](#run-grounded-edge-sam-demo)
 
 
 ### Installation
@@ -34,6 +34,7 @@ Here's the list of Efficient SAM variants:
 | [MobileSAM](https://arxiv.org/pdf/2306.14289.pdf) | ![](https://github.com/ChaoningZhang/MobileSAM/blob/master/assets/model_diagram.jpg?raw=true) | MobileSAM performs on par with the original SAM (at least visually) and keeps exactly the same pipeline as the original SAM except for a change on the image encoder. Specifically, we replace the original heavyweight ViT-H encoder (632M) with a much smaller Tiny-ViT (5M). On a single GPU, MobileSAM runs around 12ms per image: 8ms on the image encoder and 4ms on the mask decoder. | [[Github](https://github.com/ChaoningZhang/MobileSAM)] |
 | [Light-HQSAM](https://arxiv.org/pdf/2306.01567.pdf) | ![](https://github.com/SysCV/sam-hq/blob/main/figs/sam-hf-framework.png?raw=true) | Light HQ-SAM is based on the tiny vit image encoder provided by MobileSAM. We design a learnable High-Quality Output Token, which is injected into SAM's mask decoder and is responsible for predicting the high-quality mask. Instead of only applying it on mask-decoder features, we first fuse them with ViT features for improved mask details. Refer to [Light HQ-SAM vs. MobileSAM](https://github.com/SysCV/sam-hq#light-hq-sam-vs-mobilesam-on-coco) for more details. | [[Github](https://github.com/SysCV/sam-hq)] |
 | [Efficient-SAM](https://github.com/yformer/EfficientSAM) | ![](https://yformer.github.io/efficient-sam/EfficientSAM_files/overview.png) |Segment Anything Model (SAM) has emerged as a powerful tool for numerous vision applications. However, the huge computation cost of SAM model has limited its applications to wider real-world applications. To address this limitation, we propose EfficientSAMs, light-weight SAM models that exhibit decent performance with largely reduced complexity. Our idea is based on leveraging masked image pretraining, SAMI, which learns to reconstruct features from SAM image encoder for effective visual representation learning. Further, we take SAMI-pretrained light-weight image encoders and mask decoder to build EfficientSAMs, and finetune the models on SA-1B for segment anything task. Refer to [EfficientSAM arXiv](https://arxiv.org/pdf/2312.00863.pdf) for more details.| [[Github](https://github.com/yformer/EfficientSAM)] |
+| [Edge-SAM](https://github.com/chongzhou96/EdgeSAM) | ![](https://www.mmlab-ntu.com/project/edgesam/img/arch.png) | EdgeSAM involves distilling the original ViT-based SAM image encoder into a purely CNN-based architecture, better suited for edge devices. We carefully benchmark various distillation strategies and demonstrate that task-agnostic encoder distillation fails to capture the full knowledge embodied in SAM. Refer to [Edge-SAM arXiv](https://arxiv.org/abs/2312.06660) for more details. | [[Github](https://github.com/chongzhou96/EdgeSAM)]
 
 </div>
 

--- a/EfficientSAM/README.md
+++ b/EfficientSAM/README.md
@@ -19,6 +19,7 @@ We're going to combine [Grounding-DINO](https://github.com/IDEA-Research/Groundi
 
 - Install [Fast-SAM](https://github.com/CASIA-IVA-Lab/FastSAM#installation)
 
+- Note that we may use the sam image as the demo image in order to compare the inference results of different efficient-sam variants.
 
 ### Efficient SAMs
 Here's the list of Efficient SAM variants:

--- a/EfficientSAM/grounded_edge_sam.py
+++ b/EfficientSAM/grounded_edge_sam.py
@@ -104,4 +104,4 @@ annotated_image = mask_annotator.annotate(scene=image.copy(), detections=detecti
 annotated_image = box_annotator.annotate(scene=annotated_image, detections=detections, labels=labels)
 
 # save the annotated grounded-sam image
-cv2.imwrite("EfficientSAM/LightHQSAM/grounded_edge_sam_annotated_image.jpg", annotated_image)
+cv2.imwrite("EfficientSAM/grounded_edge_sam_annotated_image.jpg", annotated_image)

--- a/EfficientSAM/grounded_edge_sam.py
+++ b/EfficientSAM/grounded_edge_sam.py
@@ -19,7 +19,7 @@ GROUNDING_DINO_CHECKPOINT_PATH = "./groundingdino_swint_ogc.pth"
 grounding_dino_model = Model(model_config_path=GROUNDING_DINO_CONFIG_PATH, model_checkpoint_path=GROUNDING_DINO_CHECKPOINT_PATH)
 
 # Building MobileSAM predictor
-EdgeSAM_CHECKPOINT_PATH = "./EfficientSAM/weights/edge_sam.pth"
+EdgeSAM_CHECKPOINT_PATH = "./EfficientSAM/edge_sam_3x.pth"
 edge_sam = build_edge_sam(checkpoint=EdgeSAM_CHECKPOINT_PATH)
 edge_sam.to(device=DEVICE)
 

--- a/EfficientSAM/grounded_edge_sam.py
+++ b/EfficientSAM/grounded_edge_sam.py
@@ -7,7 +7,7 @@ import torchvision
 
 from groundingdino.util.inference import Model
 from segment_anything import SamPredictor
-from LightHQSAM.setup_light_hqsam import setup_model
+from EdgeSAM.setup_edge_sam import build_edge_sam
 
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
@@ -19,13 +19,11 @@ GROUNDING_DINO_CHECKPOINT_PATH = "./groundingdino_swint_ogc.pth"
 grounding_dino_model = Model(model_config_path=GROUNDING_DINO_CONFIG_PATH, model_checkpoint_path=GROUNDING_DINO_CHECKPOINT_PATH)
 
 # Building MobileSAM predictor
-HQSAM_CHECKPOINT_PATH = "./EfficientSAM/sam_hq_vit_tiny.pth"
-checkpoint = torch.load(HQSAM_CHECKPOINT_PATH)
-light_hqsam = setup_model()
-light_hqsam.load_state_dict(checkpoint, strict=True)
-light_hqsam.to(device=DEVICE)
+EdgeSAM_CHECKPOINT_PATH = "./EfficientSAM/weights/edge_sam.pth"
+edge_sam = build_edge_sam(checkpoint=EdgeSAM_CHECKPOINT_PATH)
+edge_sam.to(device=DEVICE)
 
-sam_predictor = SamPredictor(light_hqsam)
+sam_predictor = SamPredictor(edge_sam)
 
 
 # Predict classes and hyper-param for GroundingDINO
@@ -106,4 +104,4 @@ annotated_image = mask_annotator.annotate(scene=image.copy(), detections=detecti
 annotated_image = box_annotator.annotate(scene=annotated_image, detections=detections, labels=labels)
 
 # save the annotated grounded-sam image
-cv2.imwrite("EfficientSAM/LightHQSAM/grounded_light_hqsam_annotated_image.jpg", annotated_image)
+cv2.imwrite("EfficientSAM/LightHQSAM/grounded_edge_sam_annotated_image.jpg", annotated_image)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We are very willing to **help everyone share and promote new projects** based on
 The **core idea** behind this project is to **combine the strengths of different models in order to build a very powerful pipeline for solving complex problems**. And it's worth mentioning that this is a workflow for combining strong expert models, where **all parts can be used separately or in combination, and can be replaced with any similar but different models (like replacing Grounding DINO with GLIP or other detectors / replacing Stable-Diffusion with ControlNet or GLIGEN/ Combining with ChatGPT)**.
 
 **🍇 Updates**
-- **`2023/12/16`** Support [Grounded-Edge-SAM](https://github.com/IDEA-Research/Grounded-Segment-Anything/tree/main/EfficientSAM#run-grounded-edge-sam-demo), thanks a lot for their great work!
+- **`2023/12/16`** Support [Grounded-Edge-SAM](https://github.com/IDEA-Research/Grounded-Segment-Anything/tree/main/EfficientSAM#run-grounded-edge-sam-demo) demo, thanks a lot for their great work!
 - **`2023/12/10`** Support [Grounded-Efficient-SAM](https://github.com/IDEA-Research/Grounded-Segment-Anything/tree/main/EfficientSAM#run-grounded-efficient-sam-demo) demo, thanks a lot for their great work!
 - **`2023/11/24`** Release [RAM++](https://arxiv.org/abs/2310.15200), which is the next generation of RAM. RAM++ can recognize any category with high accuracy, including both predefined common categories and diverse open-set categories.
 - **`2023/11/23`** Release our newly proposed visual prompt counting model [T-Rex](https://github.com/IDEA-Research/T-Rex). The introduction [Video](https://www.youtube.com/watch?v=engIEhZogAQ) and [Demo](https://deepdataspace.com/playground/ivp) is available in [DDS](https://github.com/IDEA-Research/deepdataspace) now.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ We are very willing to **help everyone share and promote new projects** based on
 The **core idea** behind this project is to **combine the strengths of different models in order to build a very powerful pipeline for solving complex problems**. And it's worth mentioning that this is a workflow for combining strong expert models, where **all parts can be used separately or in combination, and can be replaced with any similar but different models (like replacing Grounding DINO with GLIP or other detectors / replacing Stable-Diffusion with ControlNet or GLIGEN/ Combining with ChatGPT)**.
 
 **🍇 Updates**
+- **`2023/12/16`** Support [Grounded-Edge-SAM](https://github.com/IDEA-Research/Grounded-Segment-Anything/tree/main/EfficientSAM#run-grounded-edge-sam-demo), thanks a lot for their great work!
 - **`2023/12/10`** Support [Grounded-Efficient-SAM](https://github.com/IDEA-Research/Grounded-Segment-Anything/tree/main/EfficientSAM#run-grounded-efficient-sam-demo) demo, thanks a lot for their great work!
 - **`2023/11/24`** Release [RAM++](https://arxiv.org/abs/2310.15200), which is the next generation of RAM. RAM++ can recognize any category with high accuracy, including both predefined common categories and diverse open-set categories.
 - **`2023/11/23`** Release our newly proposed visual prompt counting model [T-Rex](https://github.com/IDEA-Research/T-Rex). The introduction [Video](https://www.youtube.com/watch?v=engIEhZogAQ) and [Demo](https://deepdataspace.com/playground/ivp) is available in [DDS](https://github.com/IDEA-Research/deepdataspace) now.


### PR DESCRIPTION
In this PR, we support the newly proposed efficient segment anything model [EdgeSAM](https://github.com/chongzhou96/EdgeSAM) in Grounded-SAM which forms `Grounded-Edge-SAM`

Note that, we did some hack in `rep_vit.py` to make it return more than the image features in order to be adapted to our hack [predictor.py line91](https://github.com/IDEA-Research/Grounded-Segment-Anything/blob/67a340b4542b2cfebec9d9b0a2f9bfab59fecd61/segment_anything/segment_anything/predictor.py#L91)

sam-hq needs to return interm-features to enhance the mask decoder, so there will be more outputs than sam-model in predictor as:
```python
self.features, self.interm_features = self.model.image_encoder(input_image)
```

so we modify the rep_vit as:
```python
x = self.neck(x)
# hack this place because we modified the predictor of SAM for HQ-SAM in
# segment_anything/segment_anything/predictor.py line 91 to return intern features of the backbone
# self.features, self.interm_features = self.model.image_encoder(input_image)
return x, None
```
to add a place holder `None` to avoid the bug.

We will try our best to make the code cleaner to be used.

## TODO List
- [x] Add tutorial on `grounded-edge-sam`
- [x] Update README.md