### PR TITLE
Fixed Dockerfile to use CUDA 11.6 when compiling GroundingDINO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,12 @@ RUN apt-get update && apt-get install --no-install-recommends wget ffmpeg=7:* \
     && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/appuser/Grounded-Segment-Anything
-RUN python -m pip install --no-cache-dir -e segment_anything && \
-    python -m pip install --no-cache-dir -e GroundingDINO
+RUN python -m pip install --no-cache-dir -e segment_anything
+
+# When using build isolation, PyTorch with newer CUDA is installed and can't compile GroundingDINO
+RUN python -m pip install --no-cache-dir wheel
+RUN python -m pip install --no-cache-dir --no-build-isolation -e GroundingDINO
+
 WORKDIR /home/appuser
 RUN pip install --no-cache-dir diffusers[torch]==0.15.1 opencv-python==4.7.0.72 \
     pycocotools==2.0.6 matplotlib==3.5.3 \


### PR DESCRIPTION
When installing GroundingDino with build isolation PyTorch with CUDA 12.1 is installed.

This results in the following error:
```
The detected CUDA version (11.6) mismatches the version that was used to compile PyTorch (12.1). Please make sure to use the same CUDA versions.
```

Installing wheel and disabling build isolation correctly compiles GroundingDINO with CUDA 11.6.