### PR TITLE
Update build_sam_hq.py to also run on only cpu

### DIFF
--- a/segment_anything/segment_anything/build_sam_hq.py
+++ b/segment_anything/segment_anything/build_sam_hq.py
@@ -103,7 +103,8 @@ def _build_sam(
     # sam.eval()
     if checkpoint is not None:
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            state_dict = torch.load(f, map_location=device)
         info = sam.load_state_dict(state_dict, strict=False)
         print(info)
     for n, p in sam.named_parameters():


### PR DESCRIPTION
Currently we get "RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU." error while running on cpu device. Relevant issue : https://github.com/SysCV/sam-hq/issues/24 and merge commit : https://github.com/SysCV/sam-hq/pull/25/commits/24a4963d7fdefb46168062eae3c73d9bc1e00aa2