### PR TITLE
Small fix in automatic_label_simple_demo.py

### DIFF
--- a/automatic_label_simple_demo.py
+++ b/automatic_label_simple_demo.py
@@ -124,7 +124,7 @@ print(f"After NMS: {len(detections.xyxy)} boxes")
 box_annotator = sv.BoxAnnotator()
 labels = [
     f"{AUTOMATIC_CLASSES[class_id]} {confidence:0.2f}" 
-    for _, _, confidence, class_id, _ 
+    for _, _, confidence, class_id, _ , _
     in detections]
 annotated_frame = box_annotator.annotate(scene=image.copy(), detections=detections, labels=labels)
 
@@ -157,7 +157,7 @@ box_annotator = sv.BoxAnnotator()
 mask_annotator = sv.MaskAnnotator()
 labels = [
     f"{AUTOMATIC_CLASSES[class_id]} {confidence:0.2f}" 
-    for _, _, confidence, class_id, _ 
+    for _, _, confidence, class_id, _ , _
     in detections]
 annotated_image = mask_annotator.annotate(scene=image.copy(), detections=detections)
 annotated_image = box_annotator.annotate(scene=annotated_image, detections=detections, labels=labels)


### PR DESCRIPTION
With the latest install of RAM(++), the original code throws a ValueError because detections has one more entry.  This fixes it.