### PR TITLE
Small fix in grounded_sam_simple_demo.py

### DIFF
--- a/grounded_sam_simple_demo.py
+++ b/grounded_sam_simple_demo.py
@@ -50,7 +50,7 @@ detections = grounding_dino_model.predict_with_classes(
 box_annotator = sv.BoxAnnotator()
 labels = [
     f"{CLASSES[class_id]} {confidence:0.2f}" 
-    for _, _, confidence, class_id, _ 
+    for _, _, confidence, class_id, _, _
     in detections]
 annotated_frame = box_annotator.annotate(scene=image.copy(), detections=detections, labels=labels)
 
@@ -98,7 +98,7 @@ box_annotator = sv.BoxAnnotator()
 mask_annotator = sv.MaskAnnotator()
 labels = [
     f"{CLASSES[class_id]} {confidence:0.2f}" 
-    for _, _, confidence, class_id, _ 
+    for _, _, confidence, class_id, _, _
     in detections]
 annotated_image = mask_annotator.annotate(scene=image.copy(), detections=detections)
 annotated_image = box_annotator.annotate(scene=annotated_image, detections=detections, labels=labels)


### PR DESCRIPTION
Same problem as issue #460 . The `detections` object initialized from `grounding_dino_model.predict_with_classes()` now has 6 properties, so we need 6 arguments when retrieving them. The problem is fixed by adding the sixth argument, and we can just name it as `_` since we don't need it in this demo.