### PR TITLE
solve bert model huggingface connect issue

### DIFF
--- a/GroundingDINO/groundingdino/models/GroundingDINO/groundingdino.py
+++ b/GroundingDINO/groundingdino/models/GroundingDINO/groundingdino.py
@@ -56,6 +56,7 @@ class GroundingDINO(nn.Module):
         backbone,
         transformer,
         num_queries,
+        bert_base_uncased_path,
         aux_loss=False,
         iter_update=False,
         query_dim=2,
@@ -104,8 +105,8 @@ class GroundingDINO(nn.Module):
         self.dn_labelbook_size = dn_labelbook_size
 
         # bert
-        self.tokenizer = get_tokenlizer.get_tokenlizer(text_encoder_type)
-        self.bert = get_tokenlizer.get_pretrained_language_model(text_encoder_type)
+        self.tokenizer = get_tokenlizer.get_tokenlizer(text_encoder_type, bert_base_uncased_path)
+        self.bert = get_tokenlizer.get_pretrained_language_model(text_encoder_type, bert_base_uncased_path)
         self.bert.pooler.dense.weight.requires_grad_(False)
         self.bert.pooler.dense.bias.requires_grad_(False)
         self.bert = BertModelWarper(bert_model=self.bert)
@@ -372,7 +373,8 @@ def build_groundingdino(args):
     model = GroundingDINO(
         backbone,
         transformer,
-        num_queries=args.num_queries,
+        num_queries=args.num_queries,        
+        bert_base_uncased_path=args.bert_base_uncased_path,
         aux_loss=True,
         iter_update=True,
         query_dim=4,

--- a/GroundingDINO/groundingdino/util/get_tokenlizer.py
+++ b/GroundingDINO/groundingdino/util/get_tokenlizer.py
@@ -1,7 +1,7 @@
 from transformers import AutoTokenizer, BertModel, BertTokenizer, RobertaModel, RobertaTokenizerFast
 
 
-def get_tokenlizer(text_encoder_type):
+def get_tokenlizer(text_encoder_type, bert_base_uncased_path):
     if not isinstance(text_encoder_type, str):
         # print("text_encoder_type is not a str")
         if hasattr(text_encoder_type, "text_encoder_type"):
@@ -12,15 +12,26 @@ def get_tokenlizer(text_encoder_type):
             raise ValueError(
                 "Unknown type of text_encoder_type: {}".format(type(text_encoder_type))
             )
+    
+    # solve huggingface connect issue
+    if is_bert_model_use_local_path(bert_base_uncased_path) and text_encoder_type == "bert-base-uncased":
+        print("use local bert model path: {}".format(bert_base_uncased_path))
+        return AutoTokenizer.from_pretrained(bert_base_uncased_path)
+
     print("final text_encoder_type: {}".format(text_encoder_type))
 
     tokenizer = AutoTokenizer.from_pretrained(text_encoder_type)
     return tokenizer
 
 
-def get_pretrained_language_model(text_encoder_type):
+def get_pretrained_language_model(text_encoder_type, bert_base_uncased_path):
     if text_encoder_type == "bert-base-uncased":
+        if is_bert_model_use_local_path(bert_base_uncased_path):
+            return BertModel.from_pretrained(bert_base_uncased_path)
         return BertModel.from_pretrained(text_encoder_type)
     if text_encoder_type == "roberta-base":
         return RobertaModel.from_pretrained(text_encoder_type)
     raise ValueError("Unknown text_encoder_type {}".format(text_encoder_type))
+
+def is_bert_model_use_local_path(bert_base_uncased_path):
+    return bert_base_uncased_path is not None and len(bert_base_uncased_path) > 0

--- a/grounded_sam_demo.py
+++ b/grounded_sam_demo.py
@@ -44,9 +44,10 @@ def load_image(image_path):
     return image_pil, image
 
 
-def load_model(model_config_path, model_checkpoint_path, device):
+def load_model(model_config_path, model_checkpoint_path, bert_base_uncased_path, device):
     args = SLConfig.fromfile(model_config_path)
     args.device = device
+    args.bert_base_uncased_path = bert_base_uncased_path
     model = build_model(args)
     checkpoint = torch.load(model_checkpoint_path, map_location="cpu")
     load_res = model.load_state_dict(clean_state_dict(checkpoint["model"]), strict=False)
@@ -165,6 +166,7 @@ if __name__ == "__main__":
     parser.add_argument("--text_threshold", type=float, default=0.25, help="text threshold")
 
     parser.add_argument("--device", type=str, default="cpu", help="running on cpu only!, default=False")
+    parser.add_argument("--bert_base_uncased_path", type=str, required=False, help="bert_base_uncased model path, default=False")
     args = parser.parse_args()
 
     # cfg
@@ -180,13 +182,14 @@ if __name__ == "__main__":
     box_threshold = args.box_threshold
     text_threshold = args.text_threshold
     device = args.device
+    bert_base_uncased_path = args.bert_base_uncased_path
 
     # make dir
     os.makedirs(output_dir, exist_ok=True)
     # load image
     image_pil, image = load_image(image_path)
     # load model
-    model = load_model(config_file, grounded_checkpoint, device=device)
+    model = load_model(config_file, grounded_checkpoint, bert_base_uncased_path, device=device)
 
     # visualize raw image
     image_pil.save(os.path.join(output_dir, "raw_image.jpg"))


### PR DESCRIPTION
解决了连不上huggingface下载bert-base-uncased模型的问题，可以直接使用本地的模型，步骤如下：

1. 到huggingface上面下载模型bert-base-uncased，详情见https://huggingface.co/google-bert/bert-base-uncased
![image](https://github.com/user-attachments/assets/fee37f8f-5178-4d72-94ab-e9d7026961e8)

2. 运行上图的代码之后，模型会自动下载到本地，找到模型下载的本地路径，mac和linux一般在这个路径下：{user_path}/.cache/huggingface/transformers；本人亲测mac在{user_path}/.cache/huggingface/hub这个路径下
3. 运行grounded_sam_demo.py脚本添加bert_base_uncased_path参数，指定为上面的路径，需要加上具体的模型地址，下方评论有脚本运行例子，其他遇到连不上huggingface下载模型的问题都可以用此方法解决

希望此方法可以帮助到大家！

fix #504 
fix #442 
fix #346 
fix #332 
fix #286 
fix #287 
fix #75 
