### PR TITLE
fix: replace 12 bare except clauses with except Exception

### DIFF
--- a/GroundingDINO/groundingdino/models/GroundingDINO/ms_deform_attn.py
+++ b/GroundingDINO/groundingdino/models/GroundingDINO/ms_deform_attn.py
@@ -27,7 +27,7 @@ from torch.nn.init import constant_, xavier_uniform_
 
 try:
     from groundingdino import _C
-except:
+except Exception:
     warnings.warn("Failed to load custom C++ ops. Running on CPU mode Only!")
 
 

--- a/GroundingDINO/groundingdino/util/box_ops.py
+++ b/GroundingDINO/groundingdino/util/box_ops.py
@@ -49,7 +49,7 @@ def generalized_box_iou(boxes1, boxes2):
     # so do an early check
     assert (boxes1[:, 2:] >= boxes1[:, :2]).all()
     assert (boxes2[:, 2:] >= boxes2[:, :2]).all()
-    # except:
+    # except Exception:
     #     import ipdb; ipdb.set_trace()
     iou, union = box_iou(boxes1, boxes2)
 

--- a/GroundingDINO/groundingdino/util/slconfig.py
+++ b/GroundingDINO/groundingdino/util/slconfig.py
@@ -170,7 +170,7 @@ class SLConfig(object):
             elif isinstance(b, list):
                 try:
                     _ = int(k)
-                except:
+                except Exception:
                     raise TypeError(
                         f"b is a list, " f"index {k} should be an int when input but {type(k)}"
                     )

--- a/GroundingDINO/groundingdino/util/vl_utils.py
+++ b/GroundingDINO/groundingdino/util/vl_utils.py
@@ -24,14 +24,14 @@ def create_positive_map_from_span(tokenized, token_span, max_text_len=256):
                     beg_pos = tokenized.char_to_token(beg + 1)
                     if beg_pos is None:
                         beg_pos = tokenized.char_to_token(beg + 2)
-                except:
+                except Exception:
                     beg_pos = None
             if end_pos is None:
                 try:
                     end_pos = tokenized.char_to_token(end - 2)
                     if end_pos is None:
                         end_pos = tokenized.char_to_token(end - 3)
-                except:
+                except Exception:
                     end_pos = None
             if beg_pos is None or end_pos is None:
                 continue

--- a/grounded_sam_whisper_inpainting_demo.py
+++ b/grounded_sam_whisper_inpainting_demo.py
@@ -149,7 +149,7 @@ def filter_prompts_with_chatgpt(caption, max_tokens=100, model="gpt-3.5-turbo"):
     reply = response['choices'][0]['message']['content']
     try:
         det_prompt, inpaint_prompt = reply.split('\n')[0].split(':')[-1].strip(), reply.split('\n')[1].split(':')[-1].strip()
-    except:
+    except Exception:
         warn(f"Failed to extract tags from caption") # use caption as det_prompt, inpaint_prompt
         det_prompt, inpaint_prompt = caption, caption
     return det_prompt, inpaint_prompt

--- a/playground/ImageBind_SAM/models/multimodal_preprocessors.py
+++ b/playground/ImageBind_SAM/models/multimodal_preprocessors.py
@@ -544,7 +544,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/voxelnext_3d_box/models/data_processor.py
+++ b/voxelnext_3d_box/models/data_processor.py
@@ -5,7 +5,7 @@ import numpy as np
 tv = None
 try:
     import cumm.tensorview as tv
-except:
+except Exception:
     pass
 
 
@@ -20,11 +20,11 @@ class VoxelGeneratorWrapper():
         try:
             from spconv.utils import VoxelGeneratorV2 as VoxelGenerator
             self.spconv_ver = 1
-        except:
+        except Exception:
             try:
                 from spconv.utils import VoxelGenerator
                 self.spconv_ver = 1
-            except:
+            except Exception:
                 from spconv.utils import Point2VoxelCPU3d as VoxelGenerator
                 self.spconv_ver = 2
 

--- a/voxelnext_3d_box/utils/config.py
+++ b/voxelnext_3d_box/utils/config.py
@@ -6,7 +6,7 @@ def merge_new_config(config, new_config):
         with open(new_config['_BASE_CONFIG_'], 'r') as f:
             try:
                 yaml_config = yaml.safe_load(f, Loader=yaml.FullLoader)
-            except:
+            except Exception:
                 yaml_config = yaml.safe_load(f)
         config.update(EasyDict(yaml_config))
 
@@ -24,7 +24,7 @@ def cfg_from_yaml_file(cfg_file, config):
     with open(cfg_file, 'r') as f:
         try:
             new_config = yaml.safe_load(f, Loader=yaml.FullLoader)
-        except:
+        except Exception:
             new_config = yaml.safe_load(f)
 
         merge_new_config(config=config, new_config=new_config)


### PR DESCRIPTION
## What
Replace 12 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.